### PR TITLE
In cluster descheduler

### DIFF
--- a/kubernetes/clusterRoleBinding.yaml
+++ b/kubernetes/clusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: descheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: descheduler
+    namespace: default

--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: descheduler
+  namespace: default
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+            - image: docker.io/shkatara/kubernetes-descheduler:v1.0.0
+              imagePullPolicy: IfNotPresent
+              name: descheduler
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          serviceAccount: descheduler
+          serviceAccountName: descheduler
+          terminationGracePeriodSeconds: 30
+  schedule: "0 3 * * *"
+  successfulJobsHistoryLimit: 3

--- a/kubernetes/serviceAccount.yaml
+++ b/kubernetes/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: descheduler
+  namespace: default

--- a/main.go
+++ b/main.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
 )
 
 var (
@@ -18,18 +17,11 @@ var (
 )
 
 func main() {
-	var kubeconfig *string
-
-	kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	flag.Parse()
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	config, err := rest.InClusterConfig()
 	if err != nil {
 		panic(err.Error())
 	}
-	if err != nil {
-		panic(err.Error())
-	}
-
+	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
This PR adjusts the code to allow the descheduler work in-cluster as an operator. This also adds the required Kubernetes manifests to deploy the descheduler as a cronjob. 